### PR TITLE
ci: add make job for PR checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,39 @@ jobs:
 
       - run: sh ./deploy.sh
 
+  make:
+    if: github.event_name == 'pull_request'
+    needs: [build-electron]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - macOS-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-electron
+          path: ./
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn run make --publish never
+        env:
+          IS_PULL_REQUEST: true
+          CSC_LINK: ${{ secrets.MACOS_CERT_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: make-${{ matrix.os }}
+          path: |
+            .webpack
+            dist
+          retention-days: 3
+
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/tools/notarize.js
+++ b/tools/notarize.js
@@ -10,6 +10,11 @@ exports.default = async function notarizing(context) {
     return;
   }
 
+  if (process.env.IS_PULL_REQUEST) {
+    console.log(`In PR, skipping notarization`);
+    return;
+  }
+
   if (!process.env.CI) {
     console.log(`Not in CI, skipping notarization`);
     return;


### PR DESCRIPTION
That way we can make sure that the complete apps builds before a release on main branch